### PR TITLE
Fix misspelling of "manage".

### DIFF
--- a/h.sh
+++ b/h.sh
@@ -29,7 +29,7 @@ h() {
 		return
 	fi
 
-	# magae flags
+	# manage flags
 	while getopts ":idQ" opt; do
 	    case $opt in 
 	       i) _OPTS+=" -i " ;;


### PR DESCRIPTION
was spelled as "magae".
