### PR TITLE
[BUGFIX] ZSH support

### DIFF
--- a/h.sh
+++ b/h.sh
@@ -48,7 +48,7 @@ h() {
 	# check maximum allowed input
 	if (( ${#@} > 12)); then
 		echo "Too many terms. h supports a maximum of 12 groups. Consider relying on regular expression supported patterns like \"word1\\|word2\""
-		exit -1
+		return -1
 	fi;
 
 	# set zsh compatibility
@@ -69,7 +69,7 @@ h() {
 		ACK=ack-grep
 		if ! which $ACK >/dev/null 2>&1; then
 			echo "Could not find ack or ack-grep"
-			exit -1
+			return -1
 		fi
 	fi
 


### PR DESCRIPTION
On zsh (5.0.8, probaly all) the exit command used on error conditions,
ie ack not found, too many terms; was causing zsh to exit.

Replaced exit with return solved the problem while keeping backward
compatible with bash.