### PR TITLE
fix for zsh

### DIFF
--- a/h.sh
+++ b/h.sh
@@ -66,9 +66,13 @@ h() {
         local OLD_IFS="$IFS"
         IFS=','
         local _COLORS_FG=()
-        for entry in $_CSV; do
-          _COLORS_FG=("${_COLORS_FG[@]}" "$entry")
-        done
+        if [[ -n $ZSH_VERSION ]]; then
+            _COLORS_FG=($=_CSV)
+        else
+            for entry in $_CSV; do
+              _COLORS_FG=("${_COLORS_FG[@]}" "$entry")
+            done
+        fi
         IFS="$OLD_IFS"
     else
         _COLORS_FG=( 
@@ -86,9 +90,13 @@ h() {
         local OLD_IFS="$IFS"
         IFS=','
         local _COLORS_BG=()
-        for entry in $_CSV; do
-          _COLORS_BG=("${_COLORS_BG[@]}" "$entry")
-        done
+        if [[ -n $ZSH_VERSION ]]; then
+            _COLORS_BG=($=_CSV)
+        else
+            for entry in $_CSV; do
+              _COLORS_BG=("${_COLORS_BG[@]}" "$entry")
+            done
+        fi
         IFS="$OLD_IFS"
     else
         _COLORS_BG=(            


### PR DESCRIPTION
I couldn't get H_COLORS_FG and H_COLORS_BG working in Zsh with more than 1 color.

Looking at the IFS code for splitting the color string, I came across [this](https://unix.stackexchange.com/questions/685981/why-cant-i-set-ifs-in-zsh).

This patch should fix setting multiple H_COLORS_FG and H_COLORS_BG in Zsh.